### PR TITLE
Chore/Add wallet name for local testing

### DIFF
--- a/scripts/1_deploy_gaugecontroller.py
+++ b/scripts/1_deploy_gaugecontroller.py
@@ -8,6 +8,7 @@ from scripts.helper import get_addresses, network_info, gas_strategy
 
 DEFAULT_GAUGE_TYPE_NAME = 'DFX AMM Liquidity'
 DEFAULT_TYPE_WEIGHT = 1e18
+# DEPLOY_ACCT = accounts.load('hardhat')
 DEPLOY_ACCT = accounts.load('deployve')
 
 addresses = get_addresses()


### PR DESCRIPTION
This PR adds a commented wallet name for local testing

To test locally, uncomment this `hardhat` wallet in deploy scripts and comment the `deployve` wallets