### PR TITLE
Fix/CCIPSender initializer

### DIFF
--- a/deploy/scripts/testnet/hack_ccip_sender.py
+++ b/deploy/scripts/testnet/hack_ccip_sender.py
@@ -1,0 +1,46 @@
+from brownie import Contract, CcipSender, CcipSenderOld
+from brownie import accounts, interface
+
+from utils.config import DEPLOY_ACCT, DEPLOY_PROXY_ACCT, INSTANCE_ID
+from utils.logger import load_inputs
+
+# addr = "0x7ace867b3a503C6C76834ac223993FBD8963BED2"
+
+existing = load_inputs(INSTANCE_ID)
+
+
+def main():
+    # provide proxy admin with gas
+    accounts[0].transfer(DEPLOY_PROXY_ACCT, "5 ether")
+    print(DEPLOY_PROXY_ACCT.balance())
+
+    # get proxy for CCIPSender
+    sender_proxy = Contract.from_abi(
+        "DfxUpgradeableProxy",
+        existing.read_addr("ccipSender"),
+        interface.IDfxUpgradeableProxy.abi,
+    )
+
+    # new implementation
+    ccip_sender_logic = CcipSender.deploy(
+        existing.read_addr("DFX"),
+        {"from": accounts[0]},
+        # publish_source=VERIFY_CONTRACTS,
+    )
+
+    # upgrade implementation
+    sender_proxy.upgradeTo(ccip_sender_logic.address, {"from": DEPLOY_PROXY_ACCT})
+
+    sender = Contract.from_abi(
+        "CcipSender", existing.read_addr("ccipSender"), CcipSender.abi
+    )
+    sender.initialize(
+        existing.read_addr("ccipSender"), DEPLOY_ACCT, {"from": accounts[0]}
+    )
+    print(sender.admin())
+
+    # call initialize as hacker
+
+    junk = "0x8195D3496305D2DbE43B21d51e6cC77B6C9C8364"
+    hacker = "0x6cC5F688a315f3dC28A7781717a9A798a59fDA7b"
+    sender.initialize(junk, hacker, {"from": accounts[0]})

--- a/deploy/scripts/testnet/hack_ccip_sender.py
+++ b/deploy/scripts/testnet/hack_ccip_sender.py
@@ -2,29 +2,30 @@ from brownie import Contract, CcipSender, CcipSenderOld
 from brownie import accounts, interface
 
 from utils.config import DEPLOY_ACCT, DEPLOY_PROXY_ACCT, INSTANCE_ID
-from utils.logger import load_inputs
-
-# addr = "0x7ace867b3a503C6C76834ac223993FBD8963BED2"
+from utils.logger import load_inputs, load_outputs
 
 existing = load_inputs(INSTANCE_ID)
+deployed = load_outputs(INSTANCE_ID)
 
 
 def main():
     # provide proxy admin with gas
+    accounts[0].transfer(DEPLOY_ACCT, "5 ether")
     accounts[0].transfer(DEPLOY_PROXY_ACCT, "5 ether")
+    print(DEPLOY_ACCT.balance())
     print(DEPLOY_PROXY_ACCT.balance())
 
     # get proxy for CCIPSender
     sender_proxy = Contract.from_abi(
         "DfxUpgradeableProxy",
-        existing.read_addr("ccipSender"),
+        deployed.read_addr("ccipSender"),
         interface.IDfxUpgradeableProxy.abi,
     )
 
     # new implementation
     ccip_sender_logic = CcipSender.deploy(
         existing.read_addr("DFX"),
-        {"from": accounts[0]},
+        {"from": DEPLOY_ACCT},
         # publish_source=VERIFY_CONTRACTS,
     )
 
@@ -32,15 +33,13 @@ def main():
     sender_proxy.upgradeTo(ccip_sender_logic.address, {"from": DEPLOY_PROXY_ACCT})
 
     sender = Contract.from_abi(
-        "CcipSender", existing.read_addr("ccipSender"), CcipSender.abi
+        "CcipSender", deployed.read_addr("ccipSender"), CcipSender.abi
     )
     sender.initialize(
-        existing.read_addr("ccipSender"), DEPLOY_ACCT, {"from": accounts[0]}
+        deployed.read_addr("ccipSender"), DEPLOY_ACCT, {"from": accounts[0]}
     )
-    print(sender.admin())
 
     # call initialize as hacker
-
     junk = "0x8195D3496305D2DbE43B21d51e6cC77B6C9C8364"
     hacker = "0x6cC5F688a315f3dC28A7781717a9A798a59fDA7b"
     sender.initialize(junk, hacker, {"from": accounts[0]})

--- a/src/deprecated/CcipSenderOld.sol
+++ b/src/deprecated/CcipSenderOld.sol
@@ -11,7 +11,7 @@ import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import {Client} from "@chainlink/contracts-ccip/src/v0.8/ccip/libraries/Client.sol";
 import {IRouterClient} from "@chainlink/contracts-ccip/src/v0.8/ccip/interfaces/IRouterClient.sol";
 
-contract CcipSender is Initializable {
+contract CcipSenderOld is Initializable {
     // Custom errors to provide more descriptive revert messages.
     error NotEnoughBalance(uint256 currentBalance, uint256 calculatedFees); // Used to make sure contract has enough balance to cover the fees.
 
@@ -65,14 +65,14 @@ contract CcipSender is Initializable {
 
     /// @notice Contract constructor
     /// @param _DFX Address of the DFX reward token
-    constructor(address _DFX) {
+    constructor(address _DFX) initializer {
         DFX = _DFX;
     }
 
     /// @notice Initialize the contract
     /// @param _router Address of the CCIP Router contract
     /// @param _admin Address with administrative privileges
-    function initialize(address _router, address _admin) public initializer {
+    function initialize(address _router, address _admin) public {
         router = IRouterClient(_router);
         admin = _admin;
 


### PR DESCRIPTION
PR adds a fix to upgrade CCIPSender to protect against double initialization